### PR TITLE
event cannot be async anymore (?)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/json_to_pydantic/static/index.html
+++ b/json_to_pydantic/static/index.html
@@ -41,9 +41,9 @@
         "pyyaml",
         "Jinja2",
         "pydantic",
-        "https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/ad/e7/4642b7f462381799393fbad894ba4b32db00870a797f0616c197b07129a9/black-23.3.0-py3-none-any.whl",
         "https://files.pythonhosted.org/packages/35/f0/f3f36d0a87d4f2e3ceb9ba273cac9ad6fb0924f078e51c94803f10b55dbf/PySnooper-1.1.1-py2.py3-none-any.whl",
-        "https://files.pythonhosted.org/packages/91/3b/a63bafb8141b67c397841b36ad46e7469716af2b2d00cb0be2dfb9667130/isort-5.11.4-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/0a/63/4036ae70eea279c63e2304b91ee0ac182f467f24f86394ecfe726092340b/isort-5.12.0-py3-none-any.whl",
         "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl",
         "https://files.pythonhosted.org/packages/df/d8/3e1a32d305215166f5c32652c473aa766bd7809cd10b34c544dbc31facb5/inflect-5.6.2-py3-none-any.whl",
         "wheels/genson-1.2.2-py2.py3-none-any.whl",
@@ -52,7 +52,7 @@
       terminal=false
     </py-config>
 
-    <py-script src="main.py"></py-script>
+    <script type="py" src="./main.py"></script>
 
     <main class="container">
       <div class="position-relative">

--- a/json_to_pydantic/static/main.py
+++ b/json_to_pydantic/static/main.py
@@ -24,8 +24,7 @@ def convert_to_schema(input_text: str, all_optional: bool, snake_case_field: boo
     return parser.parse()
 
 
-async def convert():
-
+def convert():
     from js import document
 
     # todo: set button to disabled and show loading spinner
@@ -50,14 +49,14 @@ async def convert():
 async def load_deps():
     # install without deps using micropip to avoid several deps
     await micropip.install(
-        "https://files.pythonhosted.org/packages/af/e9/10c8eb73138bcb6b124e2fc2df7ec8b163f8710d947d9e685b22db215010/datamodel_code_generator-0.16.1-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/a3/44/bd5baa652b4d57853fc71c45bc0d25e1e28c92c54fcc6da07510fdd31ed7/datamodel_code_generator-0.21.1-py3-none-any.whl",
         deps=False,
     )
 
 
 async def setup():
     await load_deps()
-    await convert()
+    convert()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
was observing that the event handler wasn't running the convert function. removing `async` fixed it.  Maybe the events are not supposed to be async?

also:

- change from py-script tag to script type="py" for html compatibility
- update deps
- update pre-commit